### PR TITLE
Allow symbols to be used in the columns array

### DIFF
--- a/lib/nativeson/nativeson_container.rb
+++ b/lib/nativeson/nativeson_container.rb
@@ -72,7 +72,7 @@ class NativesonContainer
       @columns.each_with_index do |column, idx|
         case column 
         when Hash 
-          raise ArgumentError.new("#{__method__} :: column '#{column[:name]}' wasn't found in the ActiveRecord #{@klass.name} columns") unless all_columns.key?(column[:name])
+          raise ArgumentError.new("#{__method__} :: column '#{column[:name]}' wasn't found in the ActiveRecord #{@klass.name} columns") unless all_columns.key?(column[:name].to_s)
 
           columns_array << "#{column[:name]} AS #{column[:as]}"
         when String, Symbol 

--- a/test/lib/nativeson/nativeson_container_test.rb
+++ b/test/lib/nativeson/nativeson_container_test.rb
@@ -113,7 +113,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
   test "generate_sql with mixed column aliases and string names" do
     @query = query_defaults.merge(
       klass: "User",
-      columns: ["name", :email, {name: "id", as: "user_id"}],
+      columns: ["name", :email, {name: :id, as: "user_id"}],
       associations: {
         items: {
           klass: "Item",


### PR DESCRIPTION
Previously only strings and hashes were allowed. 