### PR TITLE
Ensure WHERE clause in JOIN statements include the table name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nativeson (1.0.10)
+    nativeson (1.0.11)
       pg
       rails (~> 6.1)
 

--- a/lib/nativeson/nativeson_container.rb
+++ b/lib/nativeson/nativeson_container.rb
@@ -83,7 +83,7 @@ class NativesonContainer
       association_sql << "      ON #{join[:on]} = #{join[:foreign_on]}"
       association_sql << "      AND #{join[:where]}" unless join[:where].blank?
     end
-    association_sql << "      WHERE #{@foreign_key} = #{@parent_table}"
+    association_sql << "      WHERE #{table_name}.#{@foreign_key} = #{@parent_table}"
     association_sql << "      AND #{@where}" unless @where.blank?
     association_sql << "      ORDER BY #{@order}" unless @order.blank?
     association_sql << "      LIMIT #{@limit}" unless @limit.blank?

--- a/lib/nativeson/version.rb
+++ b/lib/nativeson/version.rb
@@ -15,5 +15,5 @@
 #  limitations under the License.
 
 module Nativeson
-  VERSION = '1.0.10'
+  VERSION = '1.0.11'
 end

--- a/test/lib/nativeson/nativeson_container_test.rb
+++ b/test/lib/nativeson/nativeson_container_test.rb
@@ -87,7 +87,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         FROM (
           SELECT items.id , items.name
             FROM items
-            WHERE user_id = users.id
+            WHERE items.user_id = users.id
             ORDER BY items.id
         ) tmp_items
       ) AS items
@@ -122,7 +122,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         FROM (
           SELECT items.name AS item_name
             FROM items
-            WHERE user_id = users.id
+            WHERE items.user_id = users.id
             ORDER BY items.id
         ) tmp_items
       ) AS possessions
@@ -157,7 +157,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         FROM (
           SELECT items.name AS item_name
             FROM items
-            WHERE user_id = users.id
+            WHERE items.user_id = users.id
             ORDER BY items.id
         ) tmp_items
       ) AS possessions
@@ -193,7 +193,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         FROM (
           SELECT items.name AS item_name
             FROM items
-            WHERE user_id = users.id
+            WHERE items.user_id = users.id
             ORDER BY items.id
         ) tmp_items
       ) AS possessions

--- a/test/lib/nativeson_test.rb
+++ b/test/lib/nativeson_test.rb
@@ -208,6 +208,21 @@ class NativesonTest < ActiveSupport::TestCase
     assert_equal expected_json.strip, actual_json.strip
   end
 
+  test "fetch_json_by_query_hash when a json key doesn't exist" do
+    query_hash = query_defaults.merge(
+      {
+        klass: 'User',
+        columns: ['name', { json: "permissions->>'profiles'", as: 'profile_permissions' }]
+      }
+    )
+    expected_json = <<~JSON
+      [{"name":"Bart Simpson","profile_permissions":null},#{' '}
+       {"name":"Homer Simpson","profile_permissions":null}]
+    JSON
+    actual_json = Nativeson.fetch_json_by_query_hash(query_hash)[:json]
+    assert_equal expected_json.strip, actual_json.strip
+  end
+
   #  #####    ##   # #       ####      ####  #    # ###### #####  #   #
   #  #    #  #  #  # #      #         #    # #    # #      #    #  # #
   #  #    # #    # # #       ####     #    # #    # #####  #    #   #
@@ -277,14 +292,14 @@ class NativesonTest < ActiveSupport::TestCase
         FROM (
           SELECT items.name
             FROM items
-            WHERE user_id = users.id
+            WHERE items.user_id = users.id
             ORDER BY items.id
         ) tmp_items
       ) AS items , ( SELECT JSON_AGG(tmp_widgets)
         FROM (
           SELECT widgets.name
             FROM widgets
-            WHERE user_id = users.id
+            WHERE widgets.user_id = users.id
             ORDER BY widgets.id
         ) tmp_widgets
       ) AS widgets


### PR DESCRIPTION
Also bump version to 1.0.11

Fixes issues with ambiguous column names