### PR TITLE
Return an array or object depending on the association type

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,9 @@
 				"ms-azuretools.vscode-docker",
 				"SimonBo.rails-go-to-test",
 				"heyimfuzz.banner-comments",
-				"tomoki1207.pdf"
+				"tomoki1207.pdf",
+				"adpyke.vscode-sql-formatter",
+				"Shopify.ruby-lsp"
 			],
 			"settings": {
 				"rubyLsp.rubyVersionManager": "rvm"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,9 +14,10 @@
 	// This can be used to network with other containers or the host.
 	// "forwardPorts": [3000, 5432],
 
+	"onCreateCommand": "if [ -d ${containerWorkspaceFolder}/.git ]; then git config --global --add safe.diretory ${containerWorkspaceFolder}; fi",
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "bundle install && cd test/dummy && bundle exec rake db:prepare",
-	"postStartCommand": "if [ -d ${containerWorkspaceFolder}/.git ]; then git config --global --add safe.diretory ${containerWorkspaceFolder}; fi",
+	"postCreateCommand": ".devcontainer/post_create.sh",
+	"waitFor": "postCreateCommand",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+bundle install
+git checkout -- Gemfile.lock
+pushd test/dummy
+bundle exec rake db:prepare
+git checkout -- db/schema.rb
+popd

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nativeson (1.0.11)
+    nativeson (1.1.0)
       pg
       rails (~> 6.1)
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ where
 * `nativeson_hash[:sql]` is the SQL query used to generate the JSON string
 * `nativeson_hash[:json]` is the JSON string, ready to be sent to the front-end
 
+### Associations vs Joins
+
+The query hash can take an association object or a joins array (or both). The association object is used when you want a nested object in your JSON output (see the example output below for items.) Associations require that the nesting matches the database structure (the child association must have a key pointing to the parent association.) Joins are used when you want to include a joined column in the main (non-nested) output or create a custom structure.
+
+### Other ways to query
+
 Nativeson also supports two other calling interfaces:
 
 1. Pass an ActiveRecord query object to `Nativeson.fetch_json_by_rails_query`. The query you're passing must `respond_to?(:to_sql)` by producing a String containing a SQL query.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ where
 
 ### Associations vs Joins
 
-The query hash can take an association object or a joins array (or both). The association object is used when you want a nested object in your JSON output (see the example output below for items.) Associations require that the nesting matches the database structure (the child association must have a key pointing to the parent association.) Joins are used when you want to include a joined column in the main (non-nested) output or create a custom structure.
+The query hash can take an association object or a joins array (or both). The association object is used when you want a nested objects in your JSON output (see the example output below for items.) Generally this will be a `has_one` or `has_many` relationship. Associations require that the nesting matches the database structure (the child association must have a key pointing to the parent association.) Joins are used when you want to include a joined column in the main (non-nested) output or create a custom structure. If you want to include a `belongs_to` relationship, you should use `joins`. Joins are `LEFT OUTER JOIN`s unless declared differently in the `type` attribute.
 
 ### Other ways to query
 

--- a/lib/nativeson/nativeson_container.rb
+++ b/lib/nativeson/nativeson_container.rb
@@ -71,7 +71,7 @@ class NativesonContainer
 
   ################################################################
   def generate_association_sql(prefix, tmp_sql)
-    association_sql = if @reflection&.belongs_to? && @column_names.any?
+    association_sql = if (@reflection&.belongs_to? || @reflection&.has_one?) && @column_names.any?
                         ["( SELECT JSON_BUILD_OBJECT(#{json_build_object_columns})"]
                       else
                         ["( SELECT JSON_AGG(tmp_#{table_name})"]

--- a/lib/nativeson/nativeson_container.rb
+++ b/lib/nativeson/nativeson_container.rb
@@ -78,7 +78,7 @@ class NativesonContainer
     association_sql << "     , #{tmp_sql}" unless tmp_sql.blank?
     association_sql << "      FROM #{table_name}"
     joins.each_value do |join|
-      association_sql << "    JOIN #{join[:table_name]}"
+      association_sql << "    #{join.fetch(:type, 'LEFT OUTER JOIN')} #{join[:table_name]}"
       association_sql << "      AS #{join[:as]}" unless join[:as].blank?
       association_sql << "      ON #{join[:on]} = #{join[:foreign_on]}"
       association_sql << "      AND #{join[:where]}" unless join[:where].blank?
@@ -225,7 +225,7 @@ class NativesonContainer
     base_sql << "     , #{@sql}" unless @sql.blank?
     base_sql << "    FROM #{table_name}"
     joins.each_value do |join|
-      base_sql << "    JOIN #{join[:table_name]}"
+      base_sql << "    #{join.fetch(:type, 'LEFT OUTER JOIN')} #{join[:table_name]}"
       base_sql << "      AS #{join[:as]}" unless join[:as].blank?
       base_sql << "      ON #{join[:on]} = #{join[:foreign_on]}"
       base_sql << "      AND #{join[:where]}" unless join[:where].blank?
@@ -265,7 +265,8 @@ class NativesonContainer
           on: join[:on],
           foreign_on: join[:foreign_on],
           as: join[:as],
-          where: join[:where]
+          where: join[:where],
+          type: join[:type]
         }.compact
       ]
     end.to_h

--- a/lib/nativeson/version.rb
+++ b/lib/nativeson/version.rb
@@ -15,5 +15,5 @@
 #  limitations under the License.
 
 module Nativeson
-  VERSION = '1.0.11'
+  VERSION = '1.1.0'
 end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :items, dependent: :destroy
   has_many :widgets, dependent: :destroy
   has_one :user_profile, dependent: :destroy
+  has_many :sub_widgets, through: :widgets
 end
 
 #------------------------------------------------------------------------------

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   has_many :items, dependent: :destroy
+  has_many :item_prices, through: :items
   has_many :widgets, dependent: :destroy
   has_one :user_profile, dependent: :destroy
   has_many :sub_widgets, through: :widgets

--- a/test/dummy/app/models/user_profile_pic.rb
+++ b/test/dummy/app/models/user_profile_pic.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class UserProfilePic < ApplicationRecord
+  belongs_to :user_profile
 end
 
 #------------------------------------------------------------------------------

--- a/test/dummy/test/fixtures/items.yml
+++ b/test/dummy/test/fixtures/items.yml
@@ -13,6 +13,12 @@ tongs:
     united_states: 221
     mexico: 222
     germany: 223
+unowned:
+  name: Nobody owns this thing
+  product_codes:
+    united_states: 321
+    mexico: 322
+    germany: 323
 
 #------------------------------------------------------------------------------
 # Item

--- a/test/dummy/test/fixtures/sub_widgets.yml
+++ b/test/dummy/test/fixtures/sub_widgets.yml
@@ -1,14 +1,7 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the '{}' from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+---
+first:
+  widget: first
+  name: SubWidget
 
 #------------------------------------------------------------------------------
 # SubWidget

--- a/test/dummy/test/fixtures/user_profile_pics.yml
+++ b/test/dummy/test/fixtures/user_profile_pics.yml
@@ -1,14 +1,9 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the '{}' from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+---
+bart_pic:
+  user_profile: bart_profile
+  image_url: bart.jpg
+  image_width: 128px
+  image_height: 128px
 
 #------------------------------------------------------------------------------
 # UserProfilePic

--- a/test/dummy/test/fixtures/widgets.yml
+++ b/test/dummy/test/fixtures/widgets.yml
@@ -1,7 +1,7 @@
 ---
 first:
   user: homer
-  name: Green Glowy Thing
+  name: Widget
 #------------------------------------------------------------------------------
 # Widget
 #

--- a/test/lib/nativeson_test.rb
+++ b/test/lib/nativeson_test.rb
@@ -33,7 +33,58 @@ class NativesonTest < ActiveSupport::TestCase
     )
     expected_json = <<~JSON
       [{"name":"Bart Simpson","items":[{"name":"Skateboard"}],"widgets":null},#{' '}
-       {"name":"Homer Simpson","items":[{"name":"Nuclear Tongs"}],"widgets":[{"name":"Green Glowy Thing"}]}]
+       {"name":"Homer Simpson","items":[{"name":"Nuclear Tongs"}],"widgets":[{"name":"Widget"}]}]
+    JSON
+    actual_json = Nativeson.fetch_json_by_query_hash(query_hash)[:json]
+
+    assert_equal expected_json.strip, actual_json.strip
+  end
+
+  test 'fetch_json_by_query_hash with nested association' do
+    query_hash = query_defaults.merge(
+      {
+        klass: 'User',
+        columns: ['name'],
+        associations: {
+          items: {
+            klass: 'Item',
+            columns: ['name'],
+            associations: {
+              item_prices: {
+                klass: 'ItemPrice',
+                columns: ['previous_price', 'current_price']
+              }
+            }
+          },
+        }
+      }
+    )
+    expected_json = <<~JSON
+      [{"name":"Bart Simpson","items":[{"name":"Skateboard","item_prices":[{"previous_price":90,"current_price":100}]}]},#{' '}
+       {"name":"Homer Simpson","items":[{"name":"Nuclear Tongs","item_prices":[{"previous_price":9,"current_price":10}]}]}]
+    JSON
+    actual_json = Nativeson.fetch_json_by_query_hash(query_hash)[:json]
+
+    assert_equal expected_json.strip, actual_json.strip
+  end
+
+  test 'fetch_json_by_query_hash when association is the parent' do
+    query_hash = query_defaults.merge(
+      {
+        klass: 'Item',
+        columns: ['name'],
+        associations: {
+          users: {
+            klass: 'User',
+            columns: ['name'],
+
+          },
+        }
+      }
+    )
+    expected_json = <<~JSON
+      [{"name":"Bart Simpson","item_prices":[{"previous_price":90,"current_price":100, items:[{name: "Skateboard"}]}]},#{' '}
+       {"name":"Homer Simpson","item_prices":[{"previous_price":9,"current_price":10, items:[{"name":"Nuclear Tongs"}]}]}]
     JSON
     actual_json = Nativeson.fetch_json_by_query_hash(query_hash)[:json]
 
@@ -60,7 +111,7 @@ class NativesonTest < ActiveSupport::TestCase
     )
     expected_json = <<~JSON
       [{"full_name":"Bart Simpson","possessions":[{"item_name":"Skateboard"}],"widgets":null},#{' '}
-       {"full_name":"Homer Simpson","possessions":[{"item_name":"Nuclear Tongs"}],"widgets":[{"widget_name":"Green Glowy Thing"}]}]
+       {"full_name":"Homer Simpson","possessions":[{"item_name":"Nuclear Tongs"}],"widgets":[{"widget_name":"Widget"}]}]
     JSON
     actual_json = Nativeson.fetch_json_by_query_hash(query_hash)[:json]
     assert_equal expected_json.strip, actual_json.strip
@@ -102,7 +153,7 @@ class NativesonTest < ActiveSupport::TestCase
     )
     expected_json = <<~JSON
       {"users" : [{"full_name":"Bart Simpson","possessions":[{"item_name":"Skateboard"}],"widgets":null},#{' '}
-       {"full_name":"Homer Simpson","possessions":[{"item_name":"Nuclear Tongs"}],"widgets":[{"widget_name":"Green Glowy Thing"}]}]}
+       {"full_name":"Homer Simpson","possessions":[{"item_name":"Nuclear Tongs"}],"widgets":[{"widget_name":"Widget"}]}]}
     JSON
     actual_json = Nativeson.fetch_json_by_query_hash(query_hash)[:json]
     assert_equal expected_json.strip, actual_json.strip
@@ -158,7 +209,7 @@ class NativesonTest < ActiveSupport::TestCase
     assert_equal expected_json.strip, actual_json.strip
   end
 
-  test 'fetch_json_by_query_hash with deeply nested associations' do
+  test 'fetch_json_by_query_hash with deeply nested joins' do
     query_hash = query_defaults.merge(
       {
         klass: 'User',
@@ -341,7 +392,7 @@ class NativesonTest < ActiveSupport::TestCase
     )
     expected_json = <<~JSON
       [{"name":"Bart Simpson","items":[{"name":"Skateboard"}],"widgets":null},#{' '}
-       {"name":"Homer Simpson","items":[{"name":"Nuclear Tongs"}],"widgets":[{"name":"Green Glowy Thing"}]}]
+       {"name":"Homer Simpson","items":[{"name":"Nuclear Tongs"}],"widgets":[{"name":"Widget"}]}]
     JSON
     nativeson_hash = Nativeson.fetch_json_by_query_hash(query_hash, execute_query: false)
 

--- a/test/lib/nativeson_test.rb
+++ b/test/lib/nativeson_test.rb
@@ -68,7 +68,7 @@ class NativesonTest < ActiveSupport::TestCase
     assert_equal expected_json.strip, actual_json.strip
   end
 
-  test 'fetch_json_by_query_hash with nested belongs_to association' do
+  test 'fetch_json_by_query_hash with belongs_to association' do
     query_hash = query_defaults.merge(
       {
         klass: 'User',
@@ -91,6 +91,35 @@ class NativesonTest < ActiveSupport::TestCase
     expected_json = <<~JSON
       [{"name":"Bart Simpson","item_prices":[{"previous_price":90,"current_price":100,"item":{"name" : "Skateboard"}}]},#{' '}
        {"name":"Homer Simpson","item_prices":[{"previous_price":9,"current_price":10,"item":{"name" : "Nuclear Tongs"}}]}]
+    JSON
+    actual_json = Nativeson.fetch_json_by_query_hash(query_hash)[:json]
+
+    assert_equal expected_json.strip, actual_json.strip
+  end
+
+  test 'fetch_json_by_query_hash with has_one association' do
+    query_hash = query_defaults.merge(
+      {
+        klass: 'User',
+        columns: ['name'],
+        associations: {
+          items: {
+            klass: 'Item',
+            columns: %w[name],
+            associations: {
+              item_description: {
+                klass: 'ItemDescription',
+                key: 'description',
+                columns: ['description']
+              }
+            }
+          }
+        }
+      }
+    )
+    expected_json = <<~JSON
+      [{"name":"Bart Simpson","items":[{"name":"Skateboard","description":{"description" : "Green with a red stripe"}}]},#{' '}
+       {"name":"Homer Simpson","items":[{"name":"Nuclear Tongs","description":{"description" : "Two handled, to grip a carbon rod"}}]}]
     JSON
     actual_json = Nativeson.fetch_json_by_query_hash(query_hash)[:json]
 


### PR DESCRIPTION
This will allow `has_many` to continue to return an array of associated objects, but `has_one` and `belongs_to` associations will return a single object, not wrapped in an array. 

Also allows for date handling in `:name` hashes
And bumps the version to 1.1.0 (new minor version since this presumably changes the output of existing queries)