### PR TITLE
Don't split the first format string

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nativeson (1.1.3)
+    nativeson (1.1.4)
       pg
       rails (~> 6.1)
 

--- a/lib/nativeson/nativeson_container.rb
+++ b/lib/nativeson/nativeson_container.rb
@@ -150,12 +150,12 @@ class NativesonContainer
             @column_names << column[:as]
           elsif column.key?(:format)
             format_array = []
-            column[:format].each do |format_col|
-              format_array << if format_col.to_s.split('.').one?
-                "#{table_name}.#{format_col}"
-              else
-                format_col.to_s
-              end
+            column[:format].each_with_index do |format_col, idx|
+              format_array << if format_col.to_s.split('.').one? && idx != 0
+                                "#{table_name}.#{format_col}"
+                              else
+                                format_col.to_s
+                              end
             end
             columns_array << "FORMAT( '#{format_array.shift}' , #{format_array.join(' , ')} ) AS #{column[:as]}"
             @column_names << column[:as]

--- a/lib/nativeson/version.rb
+++ b/lib/nativeson/version.rb
@@ -15,5 +15,5 @@
 #  limitations under the License.
 
 module Nativeson
-  VERSION = '1.1.3'
+  VERSION = '1.1.4'
 end

--- a/test/lib/nativeson_test.rb
+++ b/test/lib/nativeson_test.rb
@@ -411,7 +411,11 @@ class NativesonTest < ActiveSupport::TestCase
     query_hash = query_defaults.merge(
       {
         klass: 'User',
-        columns: ['name', { format: ['https://imgur.com/%s?size=%sx%s', 'user_profile_pics.image_url', 'user_profile_pics.image_width', 'user_profile_pics.image_height'], as: 'profile_pic_url' }],
+        columns: ['name',
+                  {
+                    format: ['https://imgur.com/%s?size=%sx%s', 'user_profile_pics.image_url', 'user_profile_pics.image_width',
+                             'user_profile_pics.image_height'], as: 'profile_pic_url'
+                  }],
         joins: [
           { klass: 'UserProfile', on: 'user_profiles.user_id', foreign_on: 'users.id' },
           { klass: 'UserProfilePic', on: 'user_profile_pics.user_profile_id', foreign_on: 'user_profiles.id',


### PR DESCRIPTION
The tests had a dot, so I missed this. The first format string should never have the table name added, so skip the first string. 

Also bump version to 1.1.4