### PR TITLE
Add timezone support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nativeson (1.1.5)
+    nativeson (1.1.6)
       pg
       rails (~> 6.1)
 

--- a/lib/nativeson/nativeson_container.rb
+++ b/lib/nativeson/nativeson_container.rb
@@ -227,9 +227,12 @@ class NativesonContainer
     elsif column_relation.size == 2
       table = column_relation.first
       name = column_relation.last
-      raise ArgumentError, "#{__method__} :: column '#{name}' wasn't found in '#{table}' table" unless all_columns.key?(name) || joins.dig(
+      unless all_columns.key?(name) || joins.dig(
         table.to_sym, :column_names
       )&.include?(name)
+        raise ArgumentError,
+              "#{__method__} :: column '#{name}' wasn't found in '#{table}' table"
+      end
     end
   end
 
@@ -251,7 +254,9 @@ class NativesonContainer
       column_hash[:struct].each_value { |struct_column| check_column(struct_column) }
     else
       check_column(column_hash[:name] || column_hash[:json])
-      check_column(column_hash[:timezone]) if column_hash.key?(:timezone) && ActiveSupport::TimeZone[column_hash[:timezone]].nil?
+      if column_hash.key?(:timezone) && ActiveSupport::TimeZone[column_hash[:timezone]].nil?
+        check_column(column_hash[:timezone])
+      end
     end
   end
 

--- a/lib/nativeson/nativeson_container.rb
+++ b/lib/nativeson/nativeson_container.rb
@@ -142,7 +142,13 @@ class NativesonContainer
             column_string << "#{start_string}COALESCE( #{coalesce_array.join(' , ')} )#{end_string}"
           elsif column.key?(:name)
             name_string = if all_columns[column[:name].to_s.split('.').last]&.type == :datetime
-                            "TO_CHAR(#{table_name}.#{column[:name]}, 'YYYY-MM-DD\"T\"HH24:MI:SSOF:\"00\"')"
+                            if column[:timezone].nil?
+                              "TO_CHAR(#{table_name}.#{column[:name]}, 'YYYY-MM-DD\"T\"HH24:MI:SS.MSOF')"
+                            elsif ActiveSupport::TimeZone[column[:timezone]].nil?
+                              "TO_CHAR(#{table_name}.#{column[:name]} AT TIME ZONE #{column[:timezone]}, 'YYYY-MM-DD\"T\"HH24:MI:SS.MSOF')"
+                            else
+                              "TO_CHAR(#{table_name}.#{column[:name]} AT TIME ZONE '#{column[:timezone]}', 'YYYY-MM-DD\"T\"HH24:MI:SS.MSOF')"
+                            end
                           elsif column[:name].to_s.split('.').one?
                             "#{table_name}.#{column[:name]}"
                           else
@@ -185,7 +191,7 @@ class NativesonContainer
         else # column should be a string or symbol
           check_column(column)
           column_string << if all_columns[column.to_s.split('.').last]&.type == :datetime
-                             "TO_CHAR(#{table_name}.#{column}, 'YYYY-MM-DD\"T\"HH24:MI:SSOF:\"00\"') AS #{column}"
+                             "TO_CHAR(#{table_name}.#{column}, 'YYYY-MM-DD\"T\"HH24:MI:SS.MSOF') AS #{column}"
                            elsif column.to_s.split('.').one?
                              "#{table_name}.#{column}"
                            else
@@ -221,7 +227,7 @@ class NativesonContainer
     elsif column_relation.size == 2
       table = column_relation.first
       name = column_relation.last
-      raise ArgumentError, "#{__method__} :: column '#{name}' wasn't found in '#{table}' columns" unless joins.dig(
+      raise ArgumentError, "#{__method__} :: column '#{name}' wasn't found in '#{table}' table" unless all_columns.key?(name) || joins.dig(
         table.to_sym, :column_names
       )&.include?(name)
     end
@@ -245,6 +251,7 @@ class NativesonContainer
       column_hash[:struct].each_value { |struct_column| check_column(struct_column) }
     else
       check_column(column_hash[:name] || column_hash[:json])
+      check_column(column_hash[:timezone]) if column_hash.key?(:timezone) && ActiveSupport::TimeZone[column_hash[:timezone]].nil?
     end
   end
 

--- a/lib/nativeson/version.rb
+++ b/lib/nativeson/version.rb
@@ -15,5 +15,5 @@
 #  limitations under the License.
 
 module Nativeson
-  VERSION = '1.1.5'
+  VERSION = '1.1.6'
 end

--- a/test/dummy/app/models/item.rb
+++ b/test/dummy/app/models/item.rb
@@ -9,16 +9,17 @@ end
 #------------------------------------------------------------------------------
 # Item
 #
-# Name       SQL Type             Null    Primary Default
-# ---------- -------------------- ------- ------- ----------
-# id         bigint               false   true
-# user_id    bigint               true    false
-# created_at timestamp without time zone false   false
-# updated_at timestamp without time zone false   false
-# name       character varying    true    false
-# col_int    integer              true    false
-# col_float  double precision     true    false
-# col_string character varying    true    false
-# klass      character varying    true    false   Item
+# Name          SQL Type             Null    Primary Default
+# ------------- -------------------- ------- ------- ----------
+# id            bigint               false   true
+# user_id       bigint               true    false
+# created_at    timestamp without time zone false   false
+# updated_at    timestamp without time zone false   false
+# name          character varying    true    false
+# col_int       integer              true    false
+# col_float     double precision     true    false
+# col_string    character varying    true    false
+# klass         character varying    true    false   Item
+# product_codes jsonb                true    false
 #
 #------------------------------------------------------------------------------

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -11,16 +11,18 @@ end
 #------------------------------------------------------------------------------
 # User
 #
-# Name       SQL Type             Null    Primary Default
-# ---------- -------------------- ------- ------- ----------
-# id         bigint               false   true
-# created_at timestamp without time zone false   false
-# updated_at timestamp without time zone false   false
-# name       character varying    true    false
-# email      character varying    true    false
-# col_int    integer              true    false
-# col_float  double precision     true    false
-# col_string character varying    true    false
-# klass      character varying    true    false   User
+# Name        SQL Type             Null    Primary Default
+# ----------- -------------------- ------- ------- ----------
+# id          bigint               false   true
+# created_at  timestamp without time zone false   false
+# updated_at  timestamp without time zone false   false
+# name        character varying    true    false
+# email       character varying    true    false
+# col_int     integer              true    false
+# col_float   double precision     true    false
+# col_string  character varying    true    false
+# klass       character varying    true    false   User
+# permissions jsonb                true    false
+# timezone    character varying    true    false   UTC
 #
 #------------------------------------------------------------------------------

--- a/test/dummy/db/migrate/20230707203023_add_timezone_to_users.rb
+++ b/test/dummy/db/migrate/20230707203023_add_timezone_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTimezoneToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :timezone, :string, default: 'UTC'
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_230_702_001_424) do
+ActiveRecord::Schema.define(version: 20_230_707_203_023) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -120,6 +120,7 @@ ActiveRecord::Schema.define(version: 20_230_702_001_424) do
     t.string 'col_string'
     t.string 'klass', default: 'User'
     t.jsonb 'permissions'
+    t.string 'timezone', default: 'UTC'
   end
 
   create_table 'widgets', force: :cascade do |t|

--- a/test/dummy/test/fixtures/items.yml
+++ b/test/dummy/test/fixtures/items.yml
@@ -23,16 +23,17 @@ unowned:
 #------------------------------------------------------------------------------
 # Item
 #
-# Name       SQL Type             Null    Primary Default
-# ---------- -------------------- ------- ------- ----------
-# id         bigint               false   true              
-# user_id    bigint               true    false             
-# created_at timestamp without time zone false   false             
-# updated_at timestamp without time zone false   false             
-# name       character varying    true    false             
-# col_int    integer              true    false             
-# col_float  double precision     true    false             
-# col_string character varying    true    false             
-# klass      character varying    true    false   Item      
+# Name          SQL Type             Null    Primary Default
+# ------------- -------------------- ------- ------- ----------
+# id            bigint               false   true              
+# user_id       bigint               true    false             
+# created_at    timestamp without time zone false   false             
+# updated_at    timestamp without time zone false   false             
+# name          character varying    true    false             
+# col_int       integer              true    false             
+# col_float     double precision     true    false             
+# col_string    character varying    true    false             
+# klass         character varying    true    false   Item      
+# product_codes jsonb                true    false             
 #
 #------------------------------------------------------------------------------

--- a/test/dummy/test/fixtures/users.yml
+++ b/test/dummy/test/fixtures/users.yml
@@ -2,32 +2,36 @@
 homer:
   name: Homer Simpson
   email: homer.simpson@springfield.gov
-  created_at: <%= DateTime.parse("Monday 5:00pm") %>
+  created_at: <%= DateTime.parse("2022-10-20T14:30:45-04:00") %>
   permissions:
     items: permitted
     widgets: permitted
+  timezone: America/Chicago
 bart:
   name: Bart Simpson
   email: bart@geocities.com
-  created_at: <%= DateTime.parse("Tuesday 5:00pm") %>
+  created_at: <%= DateTime.parse("2022-10-21T16:30:45-04:00") %>
   col_string: Bart's String
   permissions:
     items: permitted
     widgets: not permitted
-  
+  timezone: America/Chicago
+
 #------------------------------------------------------------------------------
 # User
 #
-# Name       SQL Type             Null    Primary Default
-# ---------- -------------------- ------- ------- ----------
-# id         bigint               false   true              
-# created_at timestamp without time zone false   false             
-# updated_at timestamp without time zone false   false             
-# name       character varying    true    false             
-# email      character varying    true    false             
-# col_int    integer              true    false             
-# col_float  double precision     true    false             
-# col_string character varying    true    false             
-# klass      character varying    true    false   User      
+# Name        SQL Type             Null    Primary Default
+# ----------- -------------------- ------- ------- ----------
+# id          bigint               false   true
+# created_at  timestamp without time zone false   false
+# updated_at  timestamp without time zone false   false
+# name        character varying    true    false
+# email       character varying    true    false
+# col_int     integer              true    false
+# col_float   double precision     true    false
+# col_string  character varying    true    false
+# klass       character varying    true    false   User
+# permissions jsonb                true    false
+# timezone    character varying    true    false   UTC
 #
 #------------------------------------------------------------------------------

--- a/test/lib/nativeson_test.rb
+++ b/test/lib/nativeson_test.rb
@@ -234,8 +234,34 @@ class NativesonTest < ActiveSupport::TestCase
       columns: %i[name created_at]
     }
     expected_json = <<~JSON
-      [{"name":"Homer Simpson","created_at":"#{DateTime.parse('Monday 5:00pm').iso8601}"},#{' '}
-       {"name":"Bart Simpson","created_at":"#{DateTime.parse('Tuesday 5:00pm').iso8601}"}]
+      [{"name":"Homer Simpson","created_at":"2022-10-20T18:30:45.000+00"},#{' '}
+       {"name":"Bart Simpson","created_at":"2022-10-21T20:30:45.000+00"}]
+    JSON
+    actual_json = Nativeson.fetch_json_by_query_hash(query_hash)[:json]
+    assert_equal expected_json.strip, actual_json.strip
+  end
+
+  test 'fetch_json_by_query_hash with literal timezone' do
+    query_hash = {
+      klass: 'User',
+      columns: ['name', { name: 'created_at', timezone: 'America/Los_Angeles', as: 'created_at' }]
+    }
+    expected_json = <<~JSON
+      [{"name":"Homer Simpson","created_at":"2022-10-21T01:30:45.000+00"},#{' '}
+       {"name":"Bart Simpson","created_at":"2022-10-22T03:30:45.000+00"}]
+    JSON
+    actual_json = Nativeson.fetch_json_by_query_hash(query_hash)[:json]
+    assert_equal expected_json.strip, actual_json.strip
+  end
+
+  test 'fetch_json_by_query_hash with timezone from a column' do
+    query_hash = {
+      klass: 'User',
+      columns: ['name', { name: 'created_at', timezone: 'users.timezone', as: 'created_at' }]
+    }
+    expected_json = <<~JSON
+      [{"name":"Homer Simpson","created_at":"2022-10-20T23:30:45.000+00"},#{' '}
+       {"name":"Bart Simpson","created_at":"2022-10-22T01:30:45.000+00"}]
     JSON
     actual_json = Nativeson.fetch_json_by_query_hash(query_hash)[:json]
     assert_equal expected_json.strip, actual_json.strip
@@ -247,8 +273,8 @@ class NativesonTest < ActiveSupport::TestCase
       columns: [:name, { name: 'created_at', as: 'created' }]
     }
     expected_json = <<~JSON
-      [{"name":"Homer Simpson","created":"#{DateTime.parse('Monday 5:00pm').iso8601}"},#{' '}
-       {"name":"Bart Simpson","created":"#{DateTime.parse('Tuesday 5:00pm').iso8601}"}]
+      [{"name":"Homer Simpson","created":"2022-10-20T18:30:45.000+00"},#{' '}
+       {"name":"Bart Simpson","created":"2022-10-21T20:30:45.000+00"}]
     JSON
     actual_json = Nativeson.fetch_json_by_query_hash(query_hash)[:json]
     assert_equal expected_json.strip, actual_json.strip


### PR DESCRIPTION
You can now add a `:timezone` key to the columns hash to convert a timestamp to a given timezone. Both timezone literal strings (`America/Los_Angeles`) and references to timezone columns are supported. 

Bumps version to 1.1.6