### PR TITLE
Sanitize user inputs to `order`, `limit`, and `offset`

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+git config --global --add safe.directory /workspace
 bundle install
 git checkout -- Gemfile.lock
 pushd test/dummy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nativeson (1.1.6)
+    nativeson (1.1.7)
       pg
       rails (~> 6.1)
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ Here is a short example of the JSON output for a single User model instance with
  {"id":7,"name":"ayankfjpxlfjo_1.1359488386694","widget_id":3,"created_at":"2018-10-13T20:37:17.912943","updated_at":"2018-10-13T20:37:17.912943","col_int":335,"col_float":144.911845441697,"col_string":"gpbpeniemwpdk","klass":"SubWidget"}]}]}]}
 ```
 
+## Security
+
+`nativeson` bypasses many of ActiveRecord's SQL injection protections.  It is your responsibility to ensure that the query you pass to `Nativeson.fetch_json_by_query_hash` or `Nativeson.fetch_json_by_sql_string` is safe. Nativeson will check the `order` clause for SQL injection using ActiveRecord, but it will not check the `where` clause, or keys within the `columns` array. `to_i` will be called on the `:limit` and `:offset` values, so they should be safe. In general, it's best to avoid passing user input directly to Nativeson.
+
 ## Benchmarks
 
 We compared Nativeson to [ActiveModel::Serializer](https://github.com/rails-api/active_model_serializers) as a Rails standard and to [Panko](https://github.com/yosiat/panko_serializer), which according to <https://yosiat.github.io/panko_serializer/performance.html> is 5-10x as fast as AMS in microbenchmarking and ~3x as fast as AMS in an end-to-end Web page load test.

--- a/lib/nativeson/nativeson_container.rb
+++ b/lib/nativeson/nativeson_container.rb
@@ -38,6 +38,9 @@ class NativesonContainer
     @name = name.to_s
     @key = query[:key] || @name
     @joins = get_join_columns(query[:joins])
+    @limit = query[:limit].to_i if query[:limit]
+    @offset = query[:offset].to_i if query[:offset]
+    @klass.order(query[:order]) # raises an exception if the order is invalid
     @order = query[:order] || "#{@table_name}.#{@klass.primary_key}" || "#{@table_name}.id"
     get_all_columns
     select_columns

--- a/lib/nativeson/version.rb
+++ b/lib/nativeson/version.rb
@@ -15,5 +15,5 @@
 #  limitations under the License.
 
 module Nativeson
-  VERSION = '1.1.6'
+  VERSION = '1.1.7'
 end

--- a/test/lib/nativeson/nativeson_container_test.rb
+++ b/test/lib/nativeson/nativeson_container_test.rb
@@ -9,13 +9,13 @@ class NativesonContainerTest < ActiveSupport::TestCase
 
   def teardown
     # ensure that the query used actually generates valid SQL
-    assert_nothing_raised { Nativeson.fetch_json_by_query_hash(@query) }
+    assert_nothing_raised { ActiveRecord::Base.connection.execute(@expected_sql) } if @expected_sql.present?
   end
 
   test 'generate_sql' do
     @query = query_defaults.merge(klass: 'User', columns: %w[id name])
     @container = NativesonContainer.new(container_type: :base, query: @query)
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -27,7 +27,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with where clause' do
@@ -37,7 +37,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
       where: "users.name = 'Homer Simpson'"
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -50,13 +50,13 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with offset' do
     @query = query_defaults.merge(klass: 'User', columns: %w[id name], offset: 10)
     @container = NativesonContainer.new(container_type: :base, query: @query)
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -69,7 +69,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with associations' do
@@ -85,7 +85,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -107,7 +107,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with nested associations' do
@@ -131,7 +131,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -161,7 +161,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with inverted belongs_to association' do
@@ -188,7 +188,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -220,7 +220,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with deeply nested mixed associations' do
@@ -253,7 +253,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -294,7 +294,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with column aliases' do
@@ -311,7 +311,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -331,7 +331,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with mixed column aliases and string names' do
@@ -348,7 +348,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -370,7 +370,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with a top-level key' do
@@ -388,7 +388,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_BUILD_OBJECT('users', JSON_AGG(t))
         FROM (
           SELECT
@@ -407,7 +407,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
           LIMIT 10
         ) t;
     SQL
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with datetime column' do
@@ -417,7 +417,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
                                   })
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -428,7 +428,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
           LIMIT 10
         ) t;
     SQL
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with literal timezone' do
@@ -439,7 +439,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -450,7 +450,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
           LIMIT 10
         ) t;
     SQL
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with timezone from a column' do
@@ -461,7 +461,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -472,7 +472,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
           LIMIT 10
         ) t;
     SQL
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with joins and coalesced data' do
@@ -485,7 +485,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -499,7 +499,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with joins with an alias and conditional clause' do
@@ -516,7 +516,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     }
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -532,7 +532,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with json column' do
@@ -544,7 +544,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -556,7 +556,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with json column on a joined table' do
@@ -573,7 +573,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -588,7 +588,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with left joined table' do
@@ -608,7 +608,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -624,7 +624,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with formatted string' do
@@ -641,7 +641,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -657,7 +657,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with struct' do
@@ -676,7 +676,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -694,7 +694,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
         ) t;
     SQL
 
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
   end
 
   test 'generate_sql with struct and if condition' do
@@ -713,7 +713,7 @@ class NativesonContainerTest < ActiveSupport::TestCase
     )
     @container = NativesonContainer.new(container_type: :base, query: @query)
 
-    expected_sql = <<~SQL
+    @expected_sql = <<~SQL
       SELECT JSON_AGG(t)
         FROM (
           SELECT
@@ -733,6 +733,17 @@ class NativesonContainerTest < ActiveSupport::TestCase
           LIMIT 10
         ) t;
     SQL
-    assert_equal expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+    assert_equal @expected_sql.strip, @container.generate_sql.strip.squeeze("\n")
+  end
+
+  test 'generate_sql with an dangerous order clause' do
+    @query = {
+      klass: 'User',
+      columns: %w[name email],
+      order: "users.name ASC;update users set password='password'--"
+    }
+    assert_raises(ActiveRecord::UnknownAttributeReference) do
+      NativesonContainer.new(container_type: :base, query: @query)
+    end
   end
 end


### PR DESCRIPTION
Pagination and sorting are probably the most likely places to take user-input in the queries. (Also likely is filtering via `where` however that's not covered here.) This PR adds ActiveRecord SQL-injection protection to the `order` clause, and calls `to_i` on the `limit` and `offset` query values, which should effectively sanitize them as well. 

This also adds a note to the README warning about ActiveRecord SQL injection being bypassed in some cases by this gem. 

Bumps version to 1.1.7. 